### PR TITLE
メインイベントの情報を正しく伝えるためにmicrodataの組み直し

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,84 +13,93 @@
     <title>Hacker Tackle</title>
   </head>
 
-    <body itemscope itemtype="http://schema.org/Event">
-      <header id="overview">
-        <h1 id="logo" itemprop="name">
-          <span id="project_title">Hacker<br>Tackle</span><br>
-          <span id="project_subtitle">ハカタクル?</span>
-        </h1>
-        <p id="concept" itemprop="description">福岡のあらゆるエンジニアためのコミュニティイベント</p>
+  <body itemscope itemtype="http://schema.org/Event">
+    <header id="overview">
+      <h1 id="logo" itemprop="name">
+        <span id="project_title">Hacker<br>Tackle</span><br>
+        <span id="project_subtitle">ハカタクル?</span>
+      </h1>
+      <p id="concept" itemprop="description">福岡のあらゆるエンジニアためのコミュニティイベント</p>
 
-        <time id="date" datetime="2015-09-26"> 2015 - 09 - 26 </time>
-        <p>福岡県Ruby・コンテンツ産業振興センター</p>
-      </header>
+      <time id="date" datetime="2015-09-26"> 2015 - 09 - 26 </time>
+      <p>福岡県Ruby・コンテンツ産業振興センター</p>
+    </header>
 
-      <nav id="menu">
-        <ul>
-          <li><a href="#about" class="selected">開催概要</a></li>
-          <li><a href="#timetable">タイムテーブル</a></li>
-          <li><a href="#speaker">スピーカー情報</a></li>
-          <li><a href="#register">参加登録</a></li>
-        </ul>
-      </nav>
+    <nav id="menu">
+      <ul>
+        <li><a href="#about" class="selected">開催概要</a></li>
+        <li><a href="#timetable">タイムテーブル</a></li>
+        <li><a href="#speaker">スピーカー情報</a></li>
+        <li><a href="#register">参加登録</a></li>
+      </ul>
+    </nav>
 
-      <article id="about" class="content text selected">
-          <h2>開催概要</h2>
-          <p>ハッカー(Hacker)とは、様々なコンピュータ技術に通じる人々の総称です。<p>
-          <p>ハッカーの典型的な仕事ぶりとしては、普通の人が数日かけて行うような仕事をちょっとした機転によって一瞬で片付けるというようなものがあります。そのような域に達するには、特定のプログラミング言語や専門領域に長けているだけでなく、コンピュータ技術についての広範な知識が必要です。福岡はIT産業振興が盛んで、コミュニティ主体のさまざまな勉強会が日々開催されていますが、コンピュータ技術広範について深く議論できるイベントは定常的に開催されておらず、東京などに足を運ぶ必要がありました。</p>
-          <p>『Hacker Tackle』は、福岡でそのようなイベントを開催したいという有志によって企画されました。「ハッカー・タックル/博多・来る」の意味を持つイベント名には、福岡の中心地である博多でのハッカー同士のぶつかり稽古という意味合いが込められています。福岡ひいては九州のハッカー文化に貢献できれば何よりです。</p>
-          <p>銅鑼はありませんが、マサカリなら用意してあります。9/26には、ハッカーという言葉を知るあなたが博多に来て、本イベントに参加いただけることを心からお待ちしております。</p>
-        <section>
-          <h2>イベント要領</h2>
-          <table style="content">
-            <tbody>
-              <tr>
-                <th>開催日時</th>
-                <td><time itemprop="startDate" datetime="2015-09-26T13:00+09:00">2015年9月26日(土) 13:00</time>
-                   〜 <time itemprop="endDate" datetime="2015-09-26T18:30+09:00">18:30</time>
-                    (開場  <time itemprop="doorTime" datetime="2015-09-26T12:30+09:00">12:30</time>)</td>
-              </tr>
-              <tr itemprop="location" itemscope itemtype="http://schema.org/Place">
-                <th>会場</th>
-                <td itemprop="name">福岡県Ruby・コンテンツ産業振興センター<br>
-                  (<a href="http://frac.jp/" target="_blank">http://frac.jp/</a>)<br/>
-                  <meta itemprop="postalCode" content="8120013" />
-                  <meta itemprop="addressCounttry" content="jp" />
-                  <span itemprop="addressRegion">福岡県</span>
-                  <span itemprop="addressLocality">福岡市"</span>
-                  <span itemprop="streetAddress">博多区博多駅東１丁目１７−１</span><br />
-                地図情報：<a href="http://goo.gl/qyDrqc" target="_blank">http://goo.gl/qyDrqc</a></td>
-              </tr>
-              <tr itemprop="price">
-                <th>入場料</th>
-                <td><p><meta itemprop="priceCurrency" content="JPY" /><span itemprop="price">2000</span>円</p><small>・当日受付にて支払い</small></td>
-              </tr>
-              <tr itemprop="subEvent" itemscope  itemtype="http://schema.org/Event">
-                <th>懇親会</th>
-                <td>
-                <p>会場にてビアバッシュを開催(<time itemprop="startDate" datetime="2015-09-26T19:00+09:00"> 19:00</time>〜)</p>
-                <p><meta itemprop="priceCurrency" content="JPY" />・参加費<span itemprop="price">1000</span>円</p>
-              </tr>
-            </tbody>
-          </table>
-        </section>
-      </article>
+    <article id="about" class="content text selected">
+      <h2>開催概要</h2>
+      <p>ハッカー(Hacker)とは、様々なコンピュータ技術に通じる人々の総称です。<p>
+      <p>ハッカーの典型的な仕事ぶりとしては、普通の人が数日かけて行うような仕事をちょっとした機転によって一瞬で片付けるというようなものがあります。そのような域に達するには、特定のプログラミング言語や専門領域に長けているだけでなく、コンピュータ技術についての広範な知識が必要です。福岡はIT産業振興が盛んで、コミュニティ主体のさまざまな勉強会が日々開催されていますが、コンピュータ技術広範について深く議論できるイベントは定常的に開催されておらず、東京などに足を運ぶ必要がありました。</p>
+      <p>『Hacker Tackle』は、福岡でそのようなイベントを開催したいという有志によって企画されました。「ハッカー・タックル/博多・来る」の意味を持つイベント名には、福岡の中心地である博多でのハッカー同士のぶつかり稽古という意味合いが込められています。福岡ひいては九州のハッカー文化に貢献できれば何よりです。</p>
+      <p>銅鑼はありませんが、マサカリなら用意してあります。9/26には、ハッカーという言葉を知るあなたが博多に来て、本イベントに参加いただけることを心からお待ちしております。</p>
+      <section>
+        <h2>イベント要領</h2>
+        <table style="content">
+          <tbody>
 
-      <article id="timetable" class="content">
-        <h2>タイムテーブル</h2>
-        <p> comming soon </p>
-      </article>
+            <tr>
+              <th>開催日時</th>
+              <td><time itemprop="startDate" datetime="2015-09-26T13:00+09:00">2015年9月26日(土) 13:00</time>
+                 〜 <time itemprop="endDate" datetime="2015-09-26T18:30+09:00">18:30</time>
+                  (開場  <time itemprop="doorTime" datetime="2015-09-26T12:30+09:00">12:30</time>)</td>
+            </tr>
 
+            <tr itemprop="location" itemscope itemtype="http://schema.org/Place">
+              <th>会場</th>
+              <td><span itemprop="name">福岡県Ruby・コンテンツ産業振興センター</span><br>
+                (<a href="http://frac.jp/" target="_blank">http://frac.jp/</a>)<br/>
+                <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                <meta itemprop="postalCode" content="8120013" />
+                <meta itemprop="addressCountry" content="jp" />
+                <span itemprop="addressRegion">福岡県</span>
+                <span itemprop="addressLocality">福岡市</span>
+                <span itemprop="streetAddress">博多区博多駅東１丁目１７−１</span></p>
+                <p itemprop="geo" itemscope itemtype="http://schema.org/GeoCoordinates">地図情報：<a href="http://goo.gl/qyDrqc" target="_blank">http://goo.gl/qyDrqc</a>
+                  <meta itemprop="latitude" content="33.5903689" />
+                  <meta itemprop="longitude" content="130.4239637" />
+                </p>
+              </td>
+            </tr>
 
-      <article id="speaker" class="content" itemprop="performer">
-        <h2>登壇者</h2>
-        <p> comming soon </p>
-      </article>
+            <tr itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer">
+              <th>入場料</th>
+              <td>
+                <p><meta itemprop="priceCurrency" content="JPY" /><span itemprop="lowPrice">2000</span>円</p>
+                <small>・当日受付にて支払い</small>
+                <meta itemprop="url" content="http://hackertackle.github.io/" />
+              </td>
+            </tr>
 
-      <article id="register" class="content">
-        <h2>参加登録</h2>
-        <p> comming soon </p>
-      </article>
-      <script src="main.js"></script>
+            <tr>
+              <th>懇親会</th>
+              <td><p>会場にてビアバッシュを開催(19:00〜)</p>
+              <p>・参加費1000円</p>
+            </tr>
+
+          </tbody>
+        </table>
+      </section>
+    </article>
+    <article id="timetable" class="content">
+      <h2>タイムテーブル</h2>
+      <p> comming soon </p>
+    </article>
+    <article id="speaker" class="content" itemprop="performer">
+      <h2>登壇者</h2>
+      <p> comming soon </p>
+    </article>
+    <article id="register" class="content">
+      <h2>参加登録</h2>
+      <p> comming soon </p>
+    </article>
+    <script src="main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Microdataの内容に過不足があったので調整
SubEventとして懇親会の情報をmicrodataに設定していたけれど検索エンジンで引っ掛かる必要はないと思うので冗長性を考え削除
