### PR TITLE
DRYな感じでHTMLをクリーンアップ

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html lang="ja-JP">
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Hackertackle.GitHub.io : ">
 	<meta name="og:title" content="あらゆるプログラマのためのコミュニティイベント">
@@ -37,49 +37,33 @@
 <nav>
 	<ul class="nav-top">
 		<!--<li><a href="#" class="nav-left">開催概要</a></li>-->
-		<li><a href="./" class="nav-middle">HACKER TACKLE</a></li>
+		<li><h1><a href="./" class="nav-middle">HACKER TACKLE</a></h1></li>
 		<!--<li><a href="#" class="nav-right">参加登録</a></li>-->
 	</ul>
 
 </nav>
 
-<header class="header-pc">
+<header>
 	<div class="trapezoid"></div>
 	<p class="head01intro">あらゆるプログラマのためのコミュニティイベント</p>
-	<h1>HACKER TACKLE</h1>
-	<p class="head02date">2016.09.10 PM13:00-18:30(OPEN 12:30)</p>
-	<p class="head03place">福岡県Ruby・コンテンツ産業振興センター</p>
-	<a href="http://peatix.com/event/193097" class="header-btn">参加登録</a>
-</header>
-<header class="header-sp">
-	<div class="trapezoid"></div>
-	<p class="head01intro">福岡のあらゆるプログラマのためのコミュニティイベント</p>
-	<img src="images/web2016/main-sp-ttl.png" alt="HACKER TACKLE">
+	<p class="logo"><img src="images/web2016/main-sp-ttl.png" alt="HACKER TACKLE"></p>
 	<p class="head02date">2016.09.10 PM13:00-18:30(OPEN 12:30)</p>
 	<p class="head03place">福岡県Ruby・コンテンツ産業振興センター</p>
 	<a href="http://peatix.com/event/193097" class="header-btn">参加登録</a>
 </header>
 
 <section class="info">
-	<h2>CONCEPT</h2>
-	<p class="p-pc">
-            HackerTackleは、プログラマのための総合技術イベントです。
-            「ハッカー・タックル/博多・来る」の意味を持つイベント名には、多くのハッカーが博多に来て、さまざまな議論をぶつけあう場になればという思いがこめられています。
-            イマのプログラマにとって必要な知識を切り取った、さまざまな技術に関するセッションを用意しています。
-            ぜひ博多に来て、新しい技術を吸収し、議論をぶつけあってみませんか？
-        </p>
-	<p class="p-sp">
-            HackerTackleは、プログラマのための総合技術イベントです。
-            「ハッカー・タックル/博多・来る」の意味を持つイベント名には、多くのハッカーが博多に来て、さまざまな議論をぶつけあう場になればという思いがこめられています。
-            イマのプログラマにとって必要な知識を切り取った、さまざまな技術に関するセッションを用意しています。
-            ぜひ博多に来て、新しい技術を吸収し、議論をぶつけあってみませんか？
-        </p>
+	<h1>CONCEPT</h1>
+	<p>HackerTackleは、プログラマのための総合技術イベントです。</p>
+  <p>「ハッカー・タックル/博多・来る」の意味を持つイベント名には、多くのハッカーが博多に来て、さまざまな議論をぶつけあう場になればという思いがこめられています。</p>
+	<p>イマのプログラマにとって必要な知識を切り取った、さまざまな技術に関するセッションを用意しています。</p>
+	<p>ぜひ博多に来て、新しい技術を吸収し、議論をぶつけあってみませんか？</p>
 </section>
 
-<div class="map-container">
+<section class="map-container">
 	<div id="map"></div>
 	<div class="overlay"><div class="overlay-inner">
-		<h2>ACCESS</h2>
+		<h1>ACCESS</h1>
 		<div class="line"></div>
 		<p class="over-txt01">福岡県Ruby・コンテンツ産業<br>振興センター</p>
 		<p class="over-txt02">
@@ -92,9 +76,9 @@
 		<a href="https://goo.gl/maps/ergR2mMKudo" target="_blank">Google mapで見る</a>
 		<div class="trapezoid-bottom"></div>
 	</div></div>
-</div>
+</section>
 
-<footer><small>(C) 2016 HACKER TACKLE</small></footer>
+<footer><small>© 2016 HACKER TACKLE</small></footer>
 
 <script>
 function initMap() {
@@ -122,7 +106,7 @@ map: map,
 icon: 'images/web2016/here.png',
 visible: true
 });
-marker.setMap(map); 
+marker.setMap(map);
 }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCctzgo4qPy4EJxH6lnuQYOa1CGvZzWuYE&callback=initMap"

--- a/stylesheets/sass/web2016.scss
+++ b/stylesheets/sass/web2016.scss
@@ -12,8 +12,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
 	margin: 0;
@@ -24,7 +24,7 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
@@ -90,7 +90,7 @@ section {
 a {
 	text-decoration: none;
 }
-h2 {
+section h1 {
 	font-family: "Roboto Condensed", sans-serif;
 	font-size: 40px;
 }
@@ -109,9 +109,9 @@ nav {
 	display: -moz-flex;
 	display: -webkit-flex;
 	display: flex;
-	-webkit-justify-content: space-between; 
+	-webkit-justify-content: space-between;
 	justify-content: space-between;
-	-webkit-align-items: center; 
+	-webkit-align-items: center;
 	align-items: center;
 
 	li {
@@ -142,12 +142,7 @@ nav {
 	width: 240px;
 	@include align-x;
 }
-.header-pc {
-	display: block;
-}
-.header-sp {
-	display: none;
-}
+
 header {
 	background: url(../images/web2016/main.png) center, #000101;
 	background-repeat: no-repeat;
@@ -158,10 +153,6 @@ header {
 		top: 65px;
 		font-size: 30px;
 		width: 100%;
-	}
-	h1 {
-		text-indent: -9999px;
-		overflow: hidden;
 	}
 	.head02date {
 		bottom: 169px;
@@ -193,13 +184,10 @@ header {
 		font-family: "Hiragino Kaku Gothic ProN", sans-serif;
 		margin-top: 10px;
 	}
-	.p-pc {
+	.info p {
 			display: block;
-			white-space: pre-line;
 			padding: 0 20px;
-	}
-	.p-sp {
-		display: none;
+			margin-top:10px;
 	}
 }
 .map-container {
@@ -225,7 +213,7 @@ header {
 	-webkit-transform: translateY(-50%);
 	-ms-transform: translateY(-50%);
 
-	h2 {
+	section h1 {
 		font-weight: bold;
 		line-height: 1.6;
 	}
@@ -286,8 +274,14 @@ footer {
 	header * {
 			@include align-x;
 		}
+	.logo{
+		display:none;
 	}
+}
 @media only screen and (max-width: 899px) {
+	.logo{
+		display:block;
+	}
 	section {
 		padding: 45px 0;
 	}
@@ -305,12 +299,7 @@ footer {
 			background-position: center;
 		}
 	}
-	.header-pc {
-		display: none;
-	}
-	.header-sp {
-		display: block;
-	}
+
 	header {
 		background: url(../images/web2016/main-sp-bg.png) center, #000101;
 		background-size: cover;
@@ -327,7 +316,7 @@ footer {
 			font-size: 16px;
 			line-height: 1.6;
 			padding: 50px 0 5px;
-			white-space: pre-line;	
+			white-space: pre-line;
 		}
 		.head02date {
 			font-size: 28px;
@@ -350,15 +339,11 @@ footer {
 		height: 15px;
 	}
 	.info {
-		h2 {
+		h1 {
 			margin-bottom: 15px;
 		}
-		.p-pc {
-			display: none;
-		}
-		.p-sp {
-			display: block;
-			margin: 0 auto;
+		p {
+			margin: 10px auto;
 			width: 90%;
 			font-size: 18px;
 			white-space: normal;
@@ -411,7 +396,7 @@ footer {
 			font-size: 20px;
 			white-space: normal;
 			padding-top: 50px;
-			margin-bottom: -10px;	
+			margin-bottom: -10px;
 		}
 		.head02date {
 			font-size: 32px;

--- a/stylesheets/web2016.css
+++ b/stylesheets/web2016.css
@@ -246,7 +246,7 @@ header {
     transform: translateX(-50%);
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
-    bottom: 0; }
+    bottom: -1px; }
 
 footer {
   height: 98px;

--- a/stylesheets/web2016.css
+++ b/stylesheets/web2016.css
@@ -3,7 +3,6 @@
   Reset Style
 --------------------------------------------------
 */
-/* line 6, sass/web2016.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -22,70 +21,50 @@ time, mark, audio, video {
   border: 0;
   font-size: 100%;
   font: inherit;
-  vertical-align: baseline;
-}
+  vertical-align: baseline; }
 
 /* HTML5 display-role reset for older browsers */
-/* line 27, sass/web2016.scss */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
-  display: block;
-}
+  display: block; }
 
-/* line 31, sass/web2016.scss */
 body {
   line-height: 1;
-  -webkit-font-smoothing: antialiased;
-}
+  -webkit-font-smoothing: antialiased; }
 
-/* line 35, sass/web2016.scss */
 ol, ul {
-  list-style: none;
-}
+  list-style: none; }
 
-/* line 38, sass/web2016.scss */
 table {
   border-collapse: collapse;
-  border-spacing: 0;
-}
+  border-spacing: 0; }
 
 /*
 --------------------------------------------------
   PC Base Style
 --------------------------------------------------
 */
-/* line 80, sass/web2016.scss */
 body {
   color: #fff;
   background: #0b1d06;
   font-family: "HiraKakuProN-W6", sans-serif;
   font-size: 26px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 87, sass/web2016.scss */
 section {
-  padding: 70px 0;
-}
+  padding: 70px 0; }
 
-/* line 90, sass/web2016.scss */
 a {
-  text-decoration: none;
-}
+  text-decoration: none; }
 
-/* line 93, sass/web2016.scss */
-h2 {
+section h1 {
   font-family: "Roboto Condensed", sans-serif;
-  font-size: 40px;
-}
+  font-size: 40px; }
 
-/* line 97, sass/web2016.scss */
 nav {
   background: #082a00;
-  height: 92px;
-}
+  height: 92px; }
 
-/* line 101, sass/web2016.scss */
 .nav-top {
   max-width: 1025px;
   height: 100%;
@@ -100,58 +79,46 @@ nav {
   -webkit-justify-content: space-between;
   justify-content: space-between;
   -webkit-align-items: center;
-  align-items: center;
-}
-/* line 117, sass/web2016.scss */
-.nav-top li {
-  width: 100%;
-  /*remove when menu is added*/
-}
-/* line 120, sass/web2016.scss */
-.nav-top .nav-left {
-  color: #e6e6e6;
-}
-/* line 123, sass/web2016.scss */
-.nav-top .nav-middle {
-  height: 58px;
-  width: 448px;
-  background-image: url(../images/web2016/nav-title.png);
-  background-repeat: no-repeat;
-  text-indent: -9999px;
-  display: block;
-  margin: 0 auto;
-  /*remove when menu is added*/
-}
-/* line 132, sass/web2016.scss */
-.nav-top .nav-right {
-  background: #06d402;
-  background-image: -webkit-linear-gradient(top, #06d402, #028f09);
-  background-image: -moz-linear-gradient(top, #06d402, #028f09);
-  background-image: -ms-linear-gradient(top, #06d402, #028f09);
-  background-image: -o-linear-gradient(top, #06d402, #028f09);
-  background-image: linear-gradient(to bottom, #06d402, #028f09);
-  -webkit-border-radius: 60px;
-  -moz-border-radius: 60px;
-  border-radius: 60px;
-  color: #fff;
-  font-size: 18px;
-  border-top: solid #27ff76 1px;
-  font-weight: bold;
-  display: inline-block;
-  padding: 4px 30px 7px;
-}
-/* line 63, sass/web2016.scss */
-.nav-top .nav-right:hover {
-  background: #23fd20;
-  background-image: -webkit-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: -moz-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: -ms-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: -o-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: linear-gradient(to bottom, #23fd20, #02ba0b);
-  color: #def5de;
-}
+  align-items: center; }
+  .nav-top li {
+    width: 100%;
+    /*remove when menu is added*/ }
+  .nav-top .nav-left {
+    color: #e6e6e6; }
+  .nav-top .nav-middle {
+    height: 58px;
+    width: 448px;
+    background-image: url(../images/web2016/nav-title.png);
+    background-repeat: no-repeat;
+    text-indent: -9999px;
+    display: block;
+    margin: 0 auto;
+    /*remove when menu is added*/ }
+  .nav-top .nav-right {
+    background: #06d402;
+    background-image: -webkit-linear-gradient(top, #06d402, #028f09);
+    background-image: -moz-linear-gradient(top, #06d402, #028f09);
+    background-image: -ms-linear-gradient(top, #06d402, #028f09);
+    background-image: -o-linear-gradient(top, #06d402, #028f09);
+    background-image: linear-gradient(to bottom, #06d402, #028f09);
+    -webkit-border-radius: 60px;
+    -moz-border-radius: 60px;
+    border-radius: 60px;
+    color: #fff;
+    font-size: 18px;
+    border-top: solid #27ff76 1px;
+    font-weight: bold;
+    display: inline-block;
+    padding: 4px 30px 7px; }
+    .nav-top .nav-right:hover {
+      background: #23fd20;
+      background-image: -webkit-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: -moz-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: -ms-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: -o-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: linear-gradient(to bottom, #23fd20, #02ba0b);
+      color: #def5de; }
 
-/* line 137, sass/web2016.scss */
 .trapezoid {
   border-top: 20px solid #082a00;
   border-left: 25px solid transparent;
@@ -162,122 +129,77 @@ nav {
   left: 50%;
   transform: translateX(-50%);
   -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
-}
+  -ms-transform: translateX(-50%); }
 
-/* line 145, sass/web2016.scss */
-.header-pc {
-  display: block;
-}
-
-/* line 148, sass/web2016.scss */
-.header-sp {
-  display: none;
-}
-
-/* line 151, sass/web2016.scss */
 header {
   background: url(../images/web2016/main.png) center, #000101;
   background-repeat: no-repeat;
   position: relative;
-  height: 820px;
-}
-/* line 157, sass/web2016.scss */
-header .head01intro {
-  top: 65px;
-  font-size: 30px;
-  width: 100%;
-}
-/* line 162, sass/web2016.scss */
-header h1 {
-  text-indent: -9999px;
-  overflow: hidden;
-}
-/* line 166, sass/web2016.scss */
-header .head02date {
-  bottom: 169px;
-  font-size: 50px;
-  color: #e6e6e6;
-  font-family: "Roboto Condensed", sans-serif;
-  width: 100%;
-}
-/* line 173, sass/web2016.scss */
-header .head03place {
-  bottom: 137px;
-  font-size: 24px;
-  color: #e6e6e6;
-  width: 100%;
-}
-/* line 179, sass/web2016.scss */
-header .header-btn {
-  bottom: 68px;
-  background: #06d402;
-  background-image: -webkit-linear-gradient(top, #06d402, #028f09);
-  background-image: -moz-linear-gradient(top, #06d402, #028f09);
-  background-image: -ms-linear-gradient(top, #06d402, #028f09);
-  background-image: -o-linear-gradient(top, #06d402, #028f09);
-  background-image: linear-gradient(to bottom, #06d402, #028f09);
-  -webkit-border-radius: 60px;
-  -moz-border-radius: 60px;
-  border-radius: 60px;
-  color: #fff;
-  font-size: 18px;
-  border-top: solid #27ff76 1px;
-  font-weight: bold;
-  display: inline-block;
-  padding: 9px 70px 12px;
-}
-/* line 63, sass/web2016.scss */
-header .header-btn:hover {
-  background: #23fd20;
-  background-image: -webkit-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: -moz-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: -ms-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: -o-linear-gradient(top, #23fd20, #02ba0b);
-  background-image: linear-gradient(to bottom, #23fd20, #02ba0b);
-  color: #def5de;
-}
+  height: 820px; }
+  header .head01intro {
+    top: 65px;
+    font-size: 30px;
+    width: 100%; }
+  header .head02date {
+    bottom: 169px;
+    font-size: 50px;
+    color: #e6e6e6;
+    font-family: "Roboto Condensed", sans-serif;
+    width: 100%; }
+  header .head03place {
+    bottom: 137px;
+    font-size: 24px;
+    color: #e6e6e6;
+    width: 100%; }
+  header .header-btn {
+    bottom: 68px;
+    background: #06d402;
+    background-image: -webkit-linear-gradient(top, #06d402, #028f09);
+    background-image: -moz-linear-gradient(top, #06d402, #028f09);
+    background-image: -ms-linear-gradient(top, #06d402, #028f09);
+    background-image: -o-linear-gradient(top, #06d402, #028f09);
+    background-image: linear-gradient(to bottom, #06d402, #028f09);
+    -webkit-border-radius: 60px;
+    -moz-border-radius: 60px;
+    border-radius: 60px;
+    color: #fff;
+    font-size: 18px;
+    border-top: solid #27ff76 1px;
+    font-weight: bold;
+    display: inline-block;
+    padding: 9px 70px 12px; }
+    header .header-btn:hover {
+      background: #23fd20;
+      background-image: -webkit-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: -moz-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: -ms-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: -o-linear-gradient(top, #23fd20, #02ba0b);
+      background-image: linear-gradient(to bottom, #23fd20, #02ba0b);
+      color: #def5de; }
 
-/* line 186, sass/web2016.scss */
 .info {
-  margin: 0 auto;
-}
-/* line 189, sass/web2016.scss */
-.info p {
-  color: #e0e0e0;
-  font-size: 24px;
-  line-height: 1.5;
-  font-family: "Hiragino Kaku Gothic ProN", sans-serif;
-  margin-top: 10px;
-}
-/* line 196, sass/web2016.scss */
-.info .p-pc {
-  display: block;
-  white-space: pre-line;
-  padding: 0 20px;
-}
-/* line 201, sass/web2016.scss */
-.info .p-sp {
-  display: none;
-}
+  margin: 0 auto; }
+  .info p {
+    color: #e0e0e0;
+    font-size: 24px;
+    line-height: 1.5;
+    font-family: "Hiragino Kaku Gothic ProN", sans-serif;
+    margin-top: 10px; }
+  .info .info p {
+    display: block;
+    padding: 0 20px;
+    margin-top: 10px; }
 
-/* line 205, sass/web2016.scss */
 .map-container {
-  position: relative;
-}
+  position: relative; }
 
-/* line 208, sass/web2016.scss */
 #map {
-  height: 550px;
-}
+  height: 550px; }
 
-/* line 211, sass/web2016.scss */
 .overlay {
   max-width: 1100px;
-  margin: 0 auto;
-}
+  margin: 0 auto; }
 
-/* line 215, sass/web2016.scss */
 .overlay-inner {
   width: 420px;
   background: rgba(255, 255, 255, 0.8);
@@ -289,249 +211,168 @@ header .header-btn:hover {
   top: 50%;
   transform: translateY(-50%);
   -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-}
-/* line 228, sass/web2016.scss */
-.overlay-inner h2 {
-  font-weight: bold;
-  line-height: 1.6;
-}
-/* line 232, sass/web2016.scss */
-.overlay-inner .line {
-  margin: 0 30px;
-  height: 2px;
-  background: #000;
-}
-/* line 237, sass/web2016.scss */
-.overlay-inner .over-txt01 {
-  font-size: 24px;
-  margin: 17px 0 7px;
-  line-height: 1.2;
-  font-weight: bold;
-}
-/* line 243, sass/web2016.scss */
-.overlay-inner .over-txt02 {
-  font-family: "Hiragino Kaku Gothic ProN", sans-serif;
-  line-height: 1.6;
-}
-/* line 247, sass/web2016.scss */
-.overlay-inner em {
-  font-family: "HiraKakuProN-W6", sans-serif;
-  font-weight: bold;
-}
-/* line 251, sass/web2016.scss */
-.overlay-inner a {
-  display: inline-block;
-  color: #116200;
-  margin-top: 23px;
-}
-/* line 256, sass/web2016.scss */
-.overlay-inner .trapezoid-bottom {
-  display: none;
-  border-bottom: 20px solid #0b1d06;
-  border-left: 25px solid transparent;
-  border-right: 25px solid transparent;
-  height: 20px;
-  width: 150px;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
-  bottom: 0;
-}
-
-/* line 267, sass/web2016.scss */
-footer {
-  height: 98px;
-  position: relative;
-}
-/* line 271, sass/web2016.scss */
-footer small {
-  width: 100%;
-  font-family: "Roboto Condensed", sans-serif;
-  font-size: 18px;
-  color: #c8e3c2;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
-}
-
-@media only screen and (min-width: 900px) {
-  /* line 286, sass/web2016.scss */
-  header * {
+  -ms-transform: translateY(-50%); }
+  .overlay-inner section h1 {
+    font-weight: bold;
+    line-height: 1.6; }
+  .overlay-inner .line {
+    margin: 0 30px;
+    height: 2px;
+    background: #000; }
+  .overlay-inner .over-txt01 {
+    font-size: 24px;
+    margin: 17px 0 7px;
+    line-height: 1.2;
+    font-weight: bold; }
+  .overlay-inner .over-txt02 {
+    font-family: "Hiragino Kaku Gothic ProN", sans-serif;
+    line-height: 1.6; }
+  .overlay-inner em {
+    font-family: "HiraKakuProN-W6", sans-serif;
+    font-weight: bold; }
+  .overlay-inner a {
+    display: inline-block;
+    color: #116200;
+    margin-top: 23px; }
+  .overlay-inner .trapezoid-bottom {
+    display: none;
+    border-bottom: 20px solid #0b1d06;
+    border-left: 25px solid transparent;
+    border-right: 25px solid transparent;
+    height: 20px;
+    width: 150px;
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
-  }
-}
+    bottom: 0; }
+
+footer {
+  height: 98px;
+  position: relative; }
+  footer small {
+    width: 100%;
+    font-family: "Roboto Condensed", sans-serif;
+    font-size: 18px;
+    color: #c8e3c2;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    -webkit-transform: translate(-50%, -50%);
+    -ms-transform: translate(-50%, -50%); }
+
+@media only screen and (min-width: 900px) {
+  header * {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    -webkit-transform: translateX(-50%);
+    -ms-transform: translateX(-50%); }
+
+  .logo {
+    display: none; } }
 @media only screen and (max-width: 899px) {
-  /* line 291, sass/web2016.scss */
+  .logo {
+    display: block; }
+
   section {
-    padding: 45px 0;
-  }
+    padding: 45px 0; }
 
-  /* line 294, sass/web2016.scss */
   nav {
-    height: auto;
-  }
+    height: auto; }
 
-  /* line 298, sass/web2016.scss */
   .nav-top li {
-    padding: 10px 0;
-  }
-  /* line 301, sass/web2016.scss */
+    padding: 10px 0; }
   .nav-top .nav-middle {
     height: auto;
     width: 60%;
     background-size: contain;
-    background-position: center;
-  }
+    background-position: center; }
 
-  /* line 308, sass/web2016.scss */
-  .header-pc {
-    display: none;
-  }
-
-  /* line 311, sass/web2016.scss */
-  .header-sp {
-    display: block;
-  }
-
-  /* line 314, sass/web2016.scss */
   header {
     background: url(../images/web2016/main-sp-bg.png) center, #000101;
     background-size: cover;
-    height: auto;
-  }
-  /* line 319, sass/web2016.scss */
-  header * {
-    margin: 0 auto;
-  }
-  /* line 322, sass/web2016.scss */
-  header img {
-    width: 100%;
-  }
-  /* line 325, sass/web2016.scss */
-  header .head01intro {
-    width: 80%;
-    font-size: 16px;
-    line-height: 1.6;
-    padding: 50px 0 5px;
-    white-space: pre-line;
-  }
-  /* line 332, sass/web2016.scss */
-  header .head02date {
-    font-size: 28px;
-    margin-top: -10px;
-  }
-  /* line 336, sass/web2016.scss */
-  header .head03place {
-    width: 90%;
-    font-size: 14px;
-    margin-top: 10px;
-  }
-  /* line 341, sass/web2016.scss */
-  header .header-btn {
-    padding: 9px 0 12px;
-    width: 200px;
-    margin: 25px 0 65px;
-  }
+    height: auto; }
+    header * {
+      margin: 0 auto; }
+    header img {
+      width: 100%; }
+    header .head01intro {
+      width: 80%;
+      font-size: 16px;
+      line-height: 1.6;
+      padding: 50px 0 5px;
+      white-space: pre-line; }
+    header .head02date {
+      font-size: 28px;
+      margin-top: -10px; }
+    header .head03place {
+      width: 90%;
+      font-size: 14px;
+      margin-top: 10px; }
+    header .header-btn {
+      padding: 9px 0 12px;
+      width: 200px;
+      margin: 25px 0 65px; }
 
-  /* line 347, sass/web2016.scss */
   .trapezoid {
     width: 30%;
     border-top: 15px solid #082a00;
-    height: 15px;
-  }
+    height: 15px; }
 
-  /* line 353, sass/web2016.scss */
-  .info h2 {
-    margin-bottom: 15px;
-  }
-  /* line 356, sass/web2016.scss */
-  .info .p-pc {
-    display: none;
-  }
-  /* line 359, sass/web2016.scss */
-  .info .p-sp {
-    display: block;
-    margin: 0 auto;
+  .info h1 {
+    margin-bottom: 15px; }
+  .info p {
+    margin: 10px auto;
     width: 90%;
     font-size: 18px;
-    white-space: normal;
-  }
+    white-space: normal; }
 
-  /* line 367, sass/web2016.scss */
   #map {
-    height: 470px;
-  }
+    height: 470px; }
 
-  /* line 370, sass/web2016.scss */
   .overlay {
     width: 100%;
-    margin: 0 auto;
-  }
+    margin: 0 auto; }
 
-  /* line 374, sass/web2016.scss */
   .overlay-inner {
     width: 100%;
     font-size: 24px;
     height: 470px;
     box-sizing: border-box;
-    padding: 40px 0 90px;
-  }
-  /* line 381, sass/web2016.scss */
-  .overlay-inner .over-txt01 {
-    font-size: 20px;
-    margin: 25px 0 10px;
-  }
-  /* line 385, sass/web2016.scss */
-  .overlay-inner .over-txt02 {
-    font-size: 16px;
-  }
-  /* line 388, sass/web2016.scss */
-  .overlay-inner .line {
-    margin: 10px 30px;
-    height: 4px;
-  }
-  /* line 392, sass/web2016.scss */
-  .overlay-inner a {
-    border: 3px solid #116200;
-    -webkit-border-radius: 60px;
-    -moz-border-radius: 60px;
-    border-radius: 60px;
-    padding: 15px 50px;
-    font-size: 16px;
-  }
-  /* line 400, sass/web2016.scss */
-  .overlay-inner .trapezoid-bottom {
-    display: block;
-    width: 30%;
-    border-bottom: 15px solid #0b1d06;
-    height: 15px;
-  }
-}
+    padding: 40px 0 90px; }
+    .overlay-inner .over-txt01 {
+      font-size: 20px;
+      margin: 25px 0 10px; }
+    .overlay-inner .over-txt02 {
+      font-size: 16px; }
+    .overlay-inner .line {
+      margin: 10px 30px;
+      height: 4px; }
+    .overlay-inner a {
+      border: 3px solid #116200;
+      -webkit-border-radius: 60px;
+      -moz-border-radius: 60px;
+      border-radius: 60px;
+      padding: 15px 50px;
+      font-size: 16px; }
+    .overlay-inner .trapezoid-bottom {
+      display: block;
+      width: 30%;
+      border-bottom: 15px solid #0b1d06;
+      height: 15px; } }
 @media only screen and (min-width: 768px) and (max-width: 899px) {
-  /* line 410, sass/web2016.scss */
   header .head01intro {
     font-size: 20px;
     white-space: normal;
     padding-top: 50px;
-    margin-bottom: -10px;
-  }
-  /* line 416, sass/web2016.scss */
+    margin-bottom: -10px; }
   header .head02date {
     font-size: 32px;
-    margin-top: -35px;
-  }
-  /* line 420, sass/web2016.scss */
+    margin-top: -35px; }
   header .head03place {
-    font-size: 20px;
-  }
-}
+    font-size: 20px; } }
+
+/*# sourceMappingURL=web2016.css.map */


### PR DESCRIPTION
今は使えなくなっているChromeFrameの削除
h1が座標飛ばして非表示になっている部分、検索エンジンのペナルティ怖いのでh1から外して普通のPタグに変更
つられてh2はh1に昇格
ナビ部分のHackerTackleが見出しの役目をもっていたのでh1に変更
スマートフォン版とPC版でコードが重複していたのでDRYな感じでマージ
コンセプトだけpre-lineになっていたので普通に
（c）を © に
コンセプトが長くなっていたので段落間に空白を追加
