### PR TITLE
全体的にテキストの体裁と整える

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
 	<tr>
 		<td>15:00 - 15:50</td>
 		<td id="speaker-15-h" class="speaker"><strong>今日からKotlinでAndroid開発を始められるようになる話</strong><br>エムスリー株式会社 <br> 長澤 太郎</td>
-		<td id="speaker-15-k" class="speaker"><strong>リレーショナルデータベースとの上手な付き合い方</strong><br>日本オラクル株式会社<br>MySQL Global Business Unit<br>テクニカルアナリスト<br> 奥野幹也</td>
+		<td id="speaker-15-k" class="speaker"><strong>リレーショナルデータベースとの上手な付き合い方</strong><br>日本オラクル株式会社<br> 奥野 幹也</td>
 		<td id="speaker-15-t" class="speaker"><strong>プログラミングコンテストで遊ぼう！</strong><br>システム工房コルン <br> コルン</td>
 	</tr>
 	<tr class="row-break">
@@ -127,7 +127,7 @@
 	<tr>
 		<td>16:00 - 16:50</td>
 		<td id="speaker-16-h" class="speaker"><strong>Go言語の最新事情と並列処理についてのおさらい</strong><br>GDG中国 <br> 横山 隆司</td>
-		<td id="speaker-16-k" class="speaker"><strong>JavaでBytecode weaving！</strong>Realm <br> 山﨑 誠</td>
+		<td id="speaker-16-k" class="speaker"><strong>JavaでBytecode weaving！</strong> <br> Realm <br> 山﨑 誠</td>
 		<td id="speaker-16-t" class="speaker"><strong>ハッカーの思考でQoLを向上させよう！</strong><br>SECCON実行委員長 <br>  竹迫 良範</td>
 	</tr>
 	<tr class="row-break">
@@ -176,7 +176,7 @@
 		<li id="img-14-k"><div><img src="images/web2016profile/14-k-urushibara.jpg" alt="漆原 茂"><i class="k-lane"></i></div>漆原 茂</li>
 		<li id="img-14-t"><div><img src="images/web2016profile/14-t-matsumana.png" alt="@matsumana"><i class="t-lane"></i></div>@matsumana</li>
 		<li id="img-15-h"><div><img src="images/web2016profile/15-h-taro.jpg" alt="長澤 太郎"><i class="h-lane"></i></div>長澤 太郎</li>
-		<li id="img-15-k"><div><img src="images/web2016profile/15-k-okuno.jpg" alt="奥野幹也"><i class="k-lane"></i></div>奥野幹也</li>
+		<li id="img-15-k"><div><img src="images/web2016profile/15-k-okuno.jpg" alt="奥野 幹也"><i class="k-lane"></i></div>奥野 幹也</li>
 		<li id="img-15-t"><div><img src="images/web2016profile/15-t-colun.jpg" alt="コルン"><i class="t-lane"></i></div>コルン</li>
 		<li id="img-16-h"><div><img src="images/web2016profile/16-h-yokoyama.jpg" alt="横山 隆司"><i class="h-lane"></i></div>横山 隆司</li>
 		<li id="img-16-k"><div><img src="images/web2016profile/16-k-yamazaki.png" alt="山崎 誠"><i class="k-lane"></i></div>山崎 誠</li>
@@ -426,7 +426,7 @@
 	<div class="cancel cancel-sp">×</div>
 	<img src="images/web2016profile/17-k-maki.jpg" alt="槙 俊明">
 	<div class="popup-text">
-		<h1>Pivotal 槙 俊明</h1>
+		<h1>Pivotal <br> 槙 俊明</h1>
 		<p class="profile-links"><a href="https://blog.ik.am" target="_blank" class="blog">Blog</a>/<a href="https://twitter.com/making" target="_blank" class="twitter">Twitter</a></p>
 		<h2>いますぐ始めるCloud Foundry!<h2>
     <p>サービスを簡単に作るアプリケーションフレームワークが成熟化してきて、サービスを作りやすくなってきています。</p>


### PR DESCRIPTION
- タイムテーブルは所属+氏名で統一(肩書なし)。長い肩書の人が多くてごちゃっとしてるので
- 姓と名の間のスペースとか改行も統一
